### PR TITLE
With cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ for device in zenoss.get_devices()['devices']:
     print(device['name'])
 ```
 
+### Get event detail (use client cert for authentication)
+```python
+from zenoss import Zenoss
+
+# create Zenoss instance
+zenoss = Zenoss(
+    host = 'https://zenoss.host.com',
+    cert = '/home/user/cert.pem',
+    ssl_verify = False
+    )
+
+print zenoss.get_event_detail("e4115bd1-2290-a6f3-11e6-0568d53d97e4")
+```

--- a/examples/zenossapi-example-with-cert.py
+++ b/examples/zenossapi-example-with-cert.py
@@ -1,0 +1,12 @@
+#!/usr/local/bin/python2.7
+
+from zenoss import Zenoss
+
+# create Zenoss instance
+zenoss = Zenoss(
+            host = 'https://zenoss.host.com',
+            cert = '/home/user/cert.pem',
+            ssl_verify = False
+            )
+
+print zenoss.get_event_detail("e4115bd1-2290-a6f3-11e6-0568d53d97e4")

--- a/zenoss.py
+++ b/zenoss.py
@@ -1,5 +1,10 @@
 '''Python module to work with the Zenoss JSON API
+
+[modification] Steve Goossens: 
+* added authentication by client cert
+* changed __init__ constructor to take kwargs (to allow auth by username/password or cert)
 '''
+
 import ast
 import re
 import json
@@ -31,11 +36,21 @@ class ZenossException(Exception):
 class Zenoss(object):
     '''A class that represents a connection to a Zenoss server
     '''
-    def __init__(self, host, username, password, ssl_verify=True):
-        self.__host = host
+    def __init__(self, **kwargs):
+        self.__host = kwargs['host']
         self.__session = requests.Session()
-        self.__session.auth = (username, password)
-        self.__session.verify = ssl_verify
+        # auth by username/password or client cert
+        if 'username' in kwargs and 'password' in kwargs:
+            self.__session.auth = (kwargs['username'], kwargs['password'])
+        elif 'cert' in kwargs:
+            self.__session.cert = kwargs['cert']
+        else:
+            self.__session.auth = None
+        # host SSL verification enable/disabled
+        if 'ssl_verify' in kwargs:
+            self.__session.verify = kwargs['ssl_verify']
+        else:
+            self.__session.verify = True
         self.__req_count = 0
 
     def __router_request(self, router, method, data=None):


### PR DESCRIPTION
Hi Seth,

I've been working on Zenoss API scripting and tried to create a sub class of Zenoss to extend/override it to allow authentication by cert.  Anyway, either it's not possible due to the private class variables or I am not familiar enough with Python classes to achieve this.

Instead, I forked your repo and created a with-cert branch, and just committed this.  It *should* continue to allow for authentication by username/password, e.g. (host=https://servername, username=zenossuser, password=awesomepassword), but I have no way to test this.

I have tested my new version and it works for me using a client cert and SSL host verification disabled (also required for our servers).

This is the first time I've forked, branched, and attempted a pull request, so please feel free to point out if I've failed to follow the usual/accepted process.

Cheers,

Steve