### PR TITLE
Adding get_device_classes() method so we can get all the device class…

### DIFF
--- a/zenoss.py
+++ b/zenoss.py
@@ -81,6 +81,13 @@ class Zenoss(object):
         params = {'dsnames': dsnames, 'start': start, 'end': end, 'function': function}
         return ast.literal_eval(self.__session.get(url, params=params).content)
 
+    def get_device_classes(self):
+        '''Get a list of device classes.
+
+        '''
+        log.info('Getting all device classes')
+        return self.__router_request('DeviceRouter', 'getDeviceClasses')
+        
     def get_devices(self, device_class='/zport/dmd/Devices', limit=None):
         '''Get a list of all devices.
 


### PR DESCRIPTION
I'm creating a pull request to add get_device_classes() method. This method can be used to pull the device classes in the Zenoss system. Goal of this method is to be able to use it view and parse different device classes that we can then specify in add_device().